### PR TITLE
feat(post-install-job): add rbac

### DIFF
--- a/templates/shimexecutor-post-install-job.yaml
+++ b/templates/shimexecutor-post-install-job.yaml
@@ -21,6 +21,7 @@ spec:
         helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     spec:
       restartPolicy: Never
+      serviceAccountName: {{ .Release.Name }}-post-install
       containers:
       - name: post-install-job
         image: "bitnami/kubectl:1.30.0"
@@ -33,8 +34,65 @@ spec:
               kind: SpinAppExecutor
               metadata:
                 name: containerd-shim-spin
+                namespace: default
               spec:
                 createDeployment: true
                 deploymentConfig:
                   runtimeClassName: wasmtime-spin-v2
               EOF
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-post-install
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-post-install-role
+  namespace: default
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+rules:
+- apiGroups:
+  - core.spinoperator.dev
+  resources:
+  - spinappexecutors
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: '{{ .Release.Name }}-post-install-rolebinding'
+  namespace: default
+  labels:
+    app.kubernetes.io/component: rbac
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: '{{ .Release.Name }}-post-install-role'
+subjects:
+- kind: ServiceAccount
+  name: '{{ .Release.Name }}-post-install'
+  namespace: '{{ .Release.Namespace }}'


### PR DESCRIPTION
- Adds RBAC config so that the post-install job can create the SpinAppExecutor resource

Note that currently the resource will be created in the same namespace as the helm chart (eg `spinkube` as currently used in the Makefile).  This means SpinApps will need to be created in the same namespace (eg `kubectl -n spinkube apply myapp.yaml`)

1. Do we want to set the namespace as `default` for the SpinAppExecutor resource?  Or perhaps both the helm release namespace and default?
2. Do we want to configure a `post-delete` hook to delete this resource when the helm release is deleted (this could/would be a tricky thing especially if we're installing the SpinAppExecutor resource in a namespace other than where the helm release is installed)